### PR TITLE
fix: harden Discord attestation flow

### DIFF
--- a/SECURITY_SCAN_REPORT.md
+++ b/SECURITY_SCAN_REPORT.md
@@ -1,0 +1,276 @@
+# Security Scan Report
+
+Repository: `discord-attestation`
+Scan date: 2026-05-08
+Scope: repository-wide scan of the checked-out workspace at commit `daf4eae`
+Scan artifacts: `/tmp/codex-security-scans/discord-attestation/daf4eae_20260508T162458Z`
+
+## Executive Summary
+
+Four reportable findings survived discovery, validation, and attack-path analysis:
+
+| Priority | Severity | Finding |
+|---|---|---|
+| P1 | High | Backend and contract do not bind Discord proofs to the wallet that controls the attestation subject |
+| P2 | Medium | Signatures authorize only guild ID and subject while stored attestation fields remain mutable |
+| P2 | Medium | OAuth callback code is not bound to an unpredictable state value |
+| P2 | Medium | Discord access tokens are transported and persisted in leak-prone client-side locations |
+
+Validation performed:
+
+- `pnpm --filter @discord-attestation/contracts compile` passed.
+- `pnpm --filter @discord-attestation/frontend test -- --runInBand` passed: 6 test files, 14 tests.
+- `pnpm audit --prod --json` reported 0 production vulnerabilities across 465 production dependencies.
+
+Post-remediation status:
+
+| Priority | Remediation status |
+|---|---|
+| P1 | Mitigated on-chain by requiring the submitting wallet to match the attestation subject, plus backend validation for subject and supported chain IDs. A wallet-signed backend challenge remains useful future hardening if delegated or account-abstraction submissions become required. |
+| P2 | Fixed by signing guild ID, guild name, subject, and expiration date in the EIP-712 payload. |
+| P2 | Fixed by adding a per-login OAuth `state` value and validating it before code exchange. |
+| P2 | Fixed by removing token query-string transport, removing browser token persistence, restricting the API to `POST`, and narrowing CORS. |
+
+Post-remediation validation performed:
+
+- `pnpm --filter @discord-attestation/contracts exec hardhat compile --force`
+- `pnpm --filter @discord-attestation/contracts test`
+- `pnpm --filter @discord-attestation/frontend typecheck`
+- `pnpm --filter @discord-attestation/functions typecheck`
+- `pnpm --filter @discord-attestation/frontend test`
+- `pnpm --filter @discord-attestation/frontend build`
+- `pnpm --filter @discord-attestation/frontend test:e2e`
+- `pnpm lint`
+
+## Finding: Backend and contract do not bind Discord proofs to the wallet that controls the attestation subject
+
+Priority: P1
+Severity: High
+Confidence: High
+CWE: CWE-287 Improper Authentication, CWE-345 Insufficient Verification of Data Authenticity, CWE-862 Missing Authorization
+
+Affected lines:
+
+- `packages/functions/api.ts:106-123` reads public query parameters including `code`, `accessToken`, `subject`, and `chainId`.
+- `packages/functions/api.ts:80-91` signs typed data for the caller-provided `subject`.
+- `packages/functions/api.ts:144` returns signed guilds for that subject.
+- `packages/contracts/src/DiscordPortal.sol:53-60` verifies the signature without checking the caller/attester controls the subject.
+- `packages/contracts/src/DiscordPortal.sol:24` defines `SenderIsNotSubject()` but never uses it.
+- `packages/contracts/node_modules/@verax-attestation-registry/verax-contracts/contracts/abstracts/AbstractPortalV2.sol:73-90` stores the attestation after `_onAttest` succeeds.
+
+### Summary
+
+The API and contract both trust a caller-provided wallet subject. The backend signs Discord guild membership for whatever `subject` appears in the API query, and the contract accepts that signed `(guildId, subject)` tuple without requiring `subject == msg.sender` or `subject == getAttester()`.
+
+That means an attacker with their own valid Discord token can create a valid on-chain Discord membership attestation for a wallet they do not control.
+
+### Validation
+
+The contract compiles, and static source-to-sink tracing confirms the path:
+
+1. API reads `subject` from query parameters.
+2. API fetches guilds for a valid Discord token or code.
+3. API signs each guild ID with the supplied subject.
+4. Contract verifies signer authenticity only.
+5. Verax registry stores the submitted subject and data.
+
+Frontend behavior is not a sufficient control because the API and contract are directly callable.
+
+### Reachability Analysis
+
+This is in scope. The Netlify Function, backend signer, and Solidity portal are primary runtime surfaces. The path crosses the browser/API/backend-signer/on-chain trust boundary and affects the core product invariant: Discord membership attestations should be tied to the wallet owner.
+
+### Attack Path
+
+1. Attacker obtains a Discord OAuth code or access token for their own Discord account.
+2. Attacker calls the Netlify function directly and sets `subject` to a target wallet address.
+3. Backend signs the attacker guild IDs for the target subject.
+4. Attacker submits the signed payload through `DiscordPortal.attest`.
+5. The registry stores an attestation for the target wallet.
+
+### Severity Analysis
+
+Impact is high because the core identity assertion can be created for arbitrary wallet subjects. Likelihood is high because the path is public and requires only normal Discord credentials plus gas/fee. Final severity: High.
+
+### Remediation
+
+- Require a wallet-signed challenge before the backend signs guild memberships.
+- Bind the challenge to the Discord OAuth session, `subject`, `chainId`, and a short expiration.
+- In `DiscordPortal._onAttest`, enforce that the subject address matches `msg.sender` or `getAttester()`.
+- Add contract tests that a caller cannot attest for a different subject.
+- Add API tests that signing fails without a wallet proof for the requested subject.
+
+## Finding: Signatures authorize only guild ID and subject while stored attestation fields remain mutable
+
+Priority: P2
+Severity: Medium
+Confidence: High
+CWE: CWE-347 Improper Verification of Cryptographic Signature, CWE-345 Insufficient Verification of Data Authenticity, CWE-294 Authentication Bypass by Capture-replay
+
+Affected lines:
+
+- `packages/functions/api.ts:65-91` signs typed data containing only `id` and `subject`.
+- `packages/contracts/src/DiscordPortal.sol:59-60` decodes `GuildPayload` but verifies only `payload.guildId` and `subject`.
+- `packages/contracts/src/DiscordPortal.sol:121-124` hashes `Discord(uint256 id,address subject)`.
+- `packages/frontend/src/hooks/useAttestationManager.ts:52-58` sets one-month expiration and guild name in frontend-only code.
+- `packages/contracts/node_modules/@verax-attestation-registry/verax-contracts/contracts/AttestationRegistry.sol:122-134` stores caller-supplied `expirationDate` and `attestationData`.
+
+### Summary
+
+The backend signature authorizes only `guildId` and `subject`, but the registry stores additional caller-controlled fields such as `guildName`, `expirationDate`, and full `attestationData`. A valid signature can therefore be reused with altered metadata or a longer expiration than the frontend intended.
+
+### Validation
+
+Static tracing confirms:
+
+- The backend EIP-712 type is `Discord(uint256 id,address subject)`.
+- `DiscordPortal.verifySignature` uses only `guildId` and `subject`.
+- Verax stores `expirationDate` and `attestationData` from the submitted payload.
+
+The frontend sets sane values, but direct contract callers can bypass the frontend.
+
+### Reachability Analysis
+
+This is a public on-chain path. The attacker still needs a valid signature for the same guild ID and subject, so the issue does not let them change the core guild ID. It does let them change stored metadata and freshness semantics.
+
+### Attack Path
+
+1. Attacker obtains a valid signature for `(guildId, subject)`.
+2. Attacker submits a direct contract transaction with modified `guildName`.
+3. Attacker chooses an arbitrary expiration, including a longer-lived attestation than the frontend's one-month value.
+4. Contract accepts the signature because the signed tuple is unchanged.
+5. Registry stores the modified payload.
+
+### Severity Analysis
+
+Impact is medium: it affects integrity of stored metadata and freshness, but it does not allow arbitrary guild ID forgery with a reused signature. Likelihood is high for anyone who has a valid signature. Final severity: Medium.
+
+### Remediation
+
+- Include all security-relevant attestation fields in the EIP-712 typed data.
+- At minimum, sign `guildId`, `guildName`, `subject`, `chainId`, `verifyingContract`, and an expiration or `validUntil`.
+- Enforce a maximum expiration in the contract.
+- Consider a nonce or single-use signature model if duplicate/replay attestations are undesirable.
+- Add tests that changing `guildName` or `expirationDate` invalidates the signature.
+
+## Finding: OAuth callback code is not bound to an unpredictable state value
+
+Priority: P2
+Severity: Medium
+Confidence: Medium
+CWE: CWE-352 Cross-Site Request Forgery, CWE-384 Session Fixation
+
+Affected lines:
+
+- `packages/frontend/src/components/LoginWithDiscord.tsx:8` builds the Discord authorize URL without `state`.
+- `packages/frontend/src/components/LoginWithDiscord.tsx:12` stores only a boolean OAuth-started marker.
+- `packages/frontend/src/App.tsx:23-24` reads only `code` from the callback URL.
+- `packages/frontend/src/hooks/useFetchGuilds.ts:22-31` treats a migrated boolean marker as sufficient initial OAuth loading state.
+- `packages/frontend/src/hooks/useFetchGuilds.ts:75-89` sends the code to the API with the current subject and chain.
+- `packages/frontend/src/hooks/useFetchGuilds.ts:158-168` exchanges any present code while loading.
+
+### Summary
+
+The Discord OAuth request has no unpredictable `state` parameter, and the callback does not verify one. A local boolean marker reduces accidental processing, but it is not sent to Discord and cannot prove that a callback belongs to the login request that created the marker.
+
+### Validation
+
+Static tracing confirms the authorize URL omits `state`; callback handling reads `code` only; and the local marker is only a boolean in localStorage. No live OAuth test was run because it requires real Discord app credentials and redirect timing.
+
+### Reachability Analysis
+
+This affects the public browser OAuth flow. The strongest counterevidence is that the boolean marker prevents a completely unsolicited callback from being processed. That narrows reachability but does not provide request/response binding, especially for active or stale login attempts.
+
+### Attack Path
+
+1. Victim has an active or stale OAuth-started marker.
+2. Attacker causes a callback URL with a code from a different Discord login to be loaded.
+3. Frontend exchanges the code in the currently connected wallet context.
+4. App receives guild/signature data for the wrong Discord identity.
+5. User may create attestations under a confused identity binding.
+
+### Severity Analysis
+
+Impact is medium because this can confuse Discord identity binding in the attestation flow. Likelihood is medium because the boolean marker is a real precondition. Final severity: Medium.
+
+### Remediation
+
+- Generate a cryptographically random `state` per OAuth attempt.
+- Store it with a short lifetime.
+- Include it in the Discord authorize URL.
+- Verify the callback `state` before exchanging the code.
+- Clear the marker and state after use or failure.
+- Consider PKCE if supported by the chosen Discord OAuth/client setup.
+
+## Finding: Discord access tokens are transported and persisted in leak-prone client-side locations
+
+Priority: P2
+Severity: Medium
+Confidence: Medium-High
+CWE: CWE-598 Use of GET Request Method With Sensitive Query Strings, CWE-200 Exposure of Sensitive Information, CWE-922 Insecure Storage of Sensitive Information, CWE-613 Insufficient Session Expiration
+
+Affected lines:
+
+- `packages/functions/api.ts:108` reads `accessToken` from URL query parameters.
+- `packages/functions/api.ts:123` uses that token as the Discord bearer token.
+- `packages/functions/api.ts:146` returns the access token in JSON.
+- `packages/functions/api.ts:14-18` allows wildcard CORS on token-bearing responses.
+- `packages/frontend/src/hooks/useFetchGuilds.ts:84-89` sends restored tokens in a GET query string.
+- `packages/frontend/src/hooks/useFetchGuilds.ts:104-105` stores returned tokens.
+- `packages/frontend/src/utils/storage.ts:3-6` defines a single origin-wide token key.
+- `packages/frontend/src/utils/storage.ts:21-27` writes tokens to `window.localStorage`.
+- `packages/frontend/src/hooks/useFetchGuilds.ts:124-138` restores tokens for the currently connected wallet/session.
+
+### Summary
+
+Discord bearer tokens are returned to the browser, stored in localStorage, and later sent back to the API in GET query strings. Query strings are commonly retained in request logs and diagnostics, and localStorage is readable by any same-origin script.
+
+### Validation
+
+Static tracing confirms normal session restoration serializes `accessToken` into the API URL and the backend accepts it from `context.url.searchParams`. The repository does not prove Netlify log retention or token lifetime, so severity is capped below high.
+
+### Reachability Analysis
+
+This is a normal product path. The token crosses browser, serverless API, and Discord API boundaries. A disclosed token can be replayed to the backend endpoint to fetch guilds and obtain signing responses until the token expires or is revoked.
+
+### Attack Path
+
+1. User completes OAuth and receives a Discord access token.
+2. Frontend stores it in origin-wide localStorage.
+3. Frontend sends it in a GET URL on session restoration.
+4. Token is exposed through logs, diagnostics, local browser access, or same-origin script execution.
+5. Attacker replays the token to the API.
+
+### Severity Analysis
+
+Impact is medium because exposed tokens reveal Discord guild membership and can drive backend signing responses. Likelihood is medium-to-high because the token-in-URL path is normal app behavior, but concrete production log exposure is not proven by repository evidence. Final severity: Medium.
+
+### Remediation
+
+- Do not put access tokens in query strings.
+- Use POST bodies or `Authorization` headers if the frontend must transmit a token.
+- Prefer server-side, session-bound storage over returning Discord access tokens to the browser.
+- If browser storage remains necessary, use short lifetimes and bind restored tokens to explicit wallet/session state.
+- Restrict CORS to the application origin if token-bearing responses remain.
+
+## Coverage Closure
+
+The repository-wide coverage ledger is saved at `/tmp/codex-security-scans/discord-attestation/daf4eae_20260508T162458Z/artifacts/repository_coverage_ledger.md`.
+
+Closed as suppressed or not applicable:
+
+- SSRF/network callbacks: backend destinations are fixed Discord and Linea RPC URLs.
+- Injection/RCE/file/process sinks: no shell, eval, filesystem, template, SQL/NoSQL, dynamic import, or process execution sink was found.
+- Direct DOM XSS: React renders dynamic values in text/attribute contexts; no raw HTML or dynamic code sink was found.
+- Static analytics script execution: script source is static same-origin; the vendored bundle has analytics beacons but no dynamic code execution, storage, cookie use, or query-tracking call.
+- Deployment/operator secrets: secrets are env/config-variable based; tracked `.env.example` files contain placeholders and real `.env` files are ignored.
+- Owner-only replace/revoke: Verax portal owner checks are present.
+- Contract malformed payload DoS: malformed `validationPayloads` or `attestationData` only reverts caller-paid transactions before registry writes.
+- Unsupported-chain frontend fallback: real hardening issue, but no concrete security impact beyond likely failed or misdirected transaction context was established.
+- Dependencies: `pnpm audit --prod --json` reported zero production vulnerabilities.
+
+## Follow-Up Prompts
+
+- Review a fix for `packages/functions/api.ts` and `packages/contracts/src/DiscordPortal.sol` that adds wallet-signed challenges and enforces `subject == attester`.
+- Review a contract/API change that expands the EIP-712 typed data to include `guildName`, expiration/freshness, and nonce semantics.
+- Review an OAuth hardening change in `packages/frontend/src/components/LoginWithDiscord.tsx`, `packages/frontend/src/App.tsx`, and `packages/frontend/src/hooks/useFetchGuilds.ts` that adds `state` and removes token-in-query transport.

--- a/SEO_AUDIT_REPORT.md
+++ b/SEO_AUDIT_REPORT.md
@@ -6,7 +6,7 @@ Skill used: `.agents/skills/seo-audit`
 
 ## Executive Summary
 
-The live site had strong basic Lighthouse SEO checks, but several important SEO and performance issues were present outside Lighthouse's automated SEO score:
+The live site had strong basic Lighthouse SEO checks, but several important SEO, performance, and security issues were present outside Lighthouse's automated SEO score:
 
 - `robots.txt` and `sitemap.xml` returned `404`.
 - The page had no canonical URL and no rendered structured data.
@@ -14,8 +14,11 @@ The live site had strong basic Lighthouse SEO checks, but several important SEO 
 - Mobile performance was poor because the first page load eagerly downloaded wallet/AppKit chunks and Google Fonts.
 - Hashed static assets were served with `max-age=0,must-revalidate`.
 - OAuth codes and access tokens were sent to the Netlify function through query strings.
+- Discord attestation signatures did not bind every stored attestation field, and the contract did not require the submitting wallet to match the attestation subject.
 
 The local fixed build now scores `100/100/100/100` on mobile and desktop Lighthouse, with the initial transfer reduced from about `1,444 KiB` to `71 KiB` in the local Lighthouse run.
+
+Deployment status as of 2026-05-08 19:24 CEST: the fixes are merged to `origin/main`, but `https://discord.alainnicolas.fr/` still serves the previous build. `robots.txt` still returns `404`, the HTML still has wallet module preloads, and the canonical URL plus JSON-LD are still absent. A valid production-after Lighthouse comparison cannot be completed until the host deploys the merged commit.
 
 ## Lighthouse Baseline
 
@@ -91,7 +94,7 @@ Fix:
 
 - Moved the full wallet runtime behind a dynamic `AppRuntime` import.
 - Rendered a lightweight public shell first.
-- Loaded Reown/AppKit/Wagmi runtime only when the user clicks `Connect Wallet`, returns from OAuth, or has a stored session.
+- Loaded Reown/AppKit/Wagmi runtime only when the user clicks `Connect Wallet` or returns from OAuth.
 - Split React into a separate vendor chunk so the initial public entry no longer imports wallet chunks.
 - Disabled module preload and CSS code splitting to prevent Vite from eagerly pulling wallet chunks through preload helpers.
 
@@ -143,10 +146,12 @@ Evidence: the frontend sent `code` and `accessToken` to the Netlify function as 
 Fix:
 
 - Changed the frontend API call to `POST` with a JSON body.
-- Kept GET support in the function for backward compatibility.
 - Added OAuth `state` generation and validation.
 - Cleared `code` and `state` from the browser URL after exchange.
 - Switched production API calls to same-origin `/.netlify/functions/api` instead of a hardcoded production URL.
+- Stopped returning Discord access tokens to the browser.
+- Removed stored-token session restoration and clear legacy client-side token keys.
+- Restricted the function to `POST`/`OPTIONS`, added `Cache-Control: no-store`, and narrowed CORS to configured application origins.
 
 ### 11. Preview deployment metadata hardcoded to production
 
@@ -196,21 +201,46 @@ Fix:
 
 - Added `noopener,noreferrer` to the `window.open` call.
 
+### 16. Attestation subject was not enforced by the contract
+
+Impact: High
+Evidence: the backend signed guild membership for a caller-provided `subject`, and `DiscordPortal._onAttest` verified the backend signature without checking that the transaction sender controlled that subject.
+
+Fix:
+
+- Added a `subject == msg.sender` check in `DiscordPortal._onAttest`.
+- Added validation that exactly one backend signature is supplied.
+- Added request-side subject and chain ID validation in the Netlify function.
+
+### 17. Backend signatures did not bind all stored attestation fields
+
+Impact: Medium
+Evidence: the backend signed only Discord guild ID and subject, while the contract stored caller-supplied guild name and expiration date.
+
+Fix:
+
+- Expanded the EIP-712 payload to sign Discord guild ID, guild name, subject, and expiration date.
+- Moved expiration generation to the backend signing response.
+- Updated the frontend attestation submission to use the backend-signed expiration date.
+
 ## Validation
 
 Completed locally:
 
 - `pnpm --filter @discord-attestation/frontend typecheck`
 - `pnpm --filter @discord-attestation/functions typecheck`
+- `pnpm --filter @discord-attestation/contracts exec hardhat compile --force`
+- `pnpm --filter @discord-attestation/contracts test`
 - `pnpm --filter @discord-attestation/frontend test`
 - `pnpm --filter @discord-attestation/frontend build`
 - `pnpm --filter @discord-attestation/frontend test:e2e`
+- `pnpm lint`
 - Lighthouse mobile and desktop against `http://127.0.0.1:51973/`
 - Rendered DOM check for canonical, JSON-LD, heading structure, and wallet deferral
 
 ## Follow-up After Deployment
 
-After Netlify deploys the committed changes:
+After the host deploys the committed changes:
 
 1. Re-run Lighthouse mobile and desktop against `https://discord.alainnicolas.fr/`.
 2. Re-check `robots.txt`, `sitemap.xml`, canonical, JSON-LD, cache headers, and initial network requests in production.

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -3,6 +3,9 @@ import type { SensitiveString } from 'hardhat/types/config';
 import HardhatViem from '@nomicfoundation/hardhat-viem';
 import HardhatVerify from '@nomicfoundation/hardhat-verify';
 
+const getRpcUrl = (envKey: string, fallback: SensitiveString) =>
+  process.env[envKey] ? process.env[envKey] : fallback;
+
 export default defineConfig({
   plugins: [HardhatViem, HardhatVerify],
   solidity: {
@@ -22,13 +25,19 @@ export default defineConfig({
   networks: {
     'linea-sepolia': {
       type: 'http',
-      url: configVariable('INFURA_KEY', 'https://linea-sepolia.infura.io/v3/{variable}'),
+      url: getRpcUrl(
+        'LINEA_SEPOLIA_RPC_URL',
+        configVariable('INFURA_KEY', 'https://linea-sepolia.infura.io/v3/{variable}'),
+      ),
       accounts: [configVariable('PRIVATE_KEY') as SensitiveString],
       chainId: 59141,
     },
     linea: {
       type: 'http',
-      url: configVariable('INFURA_KEY', 'https://linea-mainnet.infura.io/v3/{variable}'),
+      url: getRpcUrl(
+        'LINEA_RPC_URL',
+        configVariable('INFURA_KEY', 'https://linea-mainnet.infura.io/v3/{variable}'),
+      ),
       accounts: [configVariable('PRIVATE_KEY') as SensitiveString],
       chainId: 59144,
     },

--- a/packages/contracts/src/DiscordPortal.sol
+++ b/packages/contracts/src/DiscordPortal.sol
@@ -18,6 +18,9 @@ contract DiscordPortal is AbstractPortalV2, Ownable, EIP712 {
     bytes32 public constant SCHEMA_ID = 0xefa96ce61912c5bb59cb4c26645ea193fc03a234fe09a6b2c8b85aaa51a382d6;
     string private constant SIGNING_DOMAIN = "VerifyDiscord";
     string private constant SIGNATURE_VERSION = "1";
+    bytes32 private constant DISCORD_TYPEHASH = keccak256(
+        "Discord(uint256 id,string name,address subject,uint64 expirationDate)"
+    );
 
     error InvalidSchema();
     error InvalidSubject();
@@ -52,12 +55,22 @@ contract DiscordPortal is AbstractPortalV2, Ownable, EIP712 {
     ) internal view override {
         if (attestationPayload.subject.length != 20) revert InvalidSubject();
         address subject = address(uint160(bytes20(attestationPayload.subject)));
+        if (subject != msg.sender) revert SenderIsNotSubject();
 
         if (value < fee) revert InsufficientFee();
         if (attestationPayload.schemaId != SCHEMA_ID) revert InvalidSchema();
+        if (validationPayloads.length != 1) revert InvalidSignatureLength();
 
         GuildPayload memory payload = abi.decode(attestationPayload.attestationData, (GuildPayload));
-        if (!verifySignature(validationPayloads[0], payload.guildId, subject)) revert InvalidSignature();
+        if (
+            !verifySignature(
+                validationPayloads[0],
+                payload.guildId,
+                payload.guildName,
+                subject,
+                attestationPayload.expirationDate
+            )
+        ) revert InvalidSignature();
     }
 
     /**
@@ -118,9 +131,15 @@ contract DiscordPortal is AbstractPortalV2, Ownable, EIP712 {
         fee = attestationFee;
     }
 
-    function verifySignature(bytes memory signature, uint256 guildId, address subject) internal view returns (bool) {
+    function verifySignature(
+        bytes memory signature,
+        uint256 guildId,
+        string memory guildName,
+        address subject,
+        uint64 expirationDate
+    ) internal view returns (bool) {
         bytes32 digest = _hashTypedDataV4(
-            keccak256(abi.encode(keccak256("Discord(uint256 id,address subject)"), guildId, subject))
+            keccak256(abi.encode(DISCORD_TYPEHASH, guildId, keccak256(bytes(guildName)), subject, expirationDate))
         );
         address signer = ECDSA.recover(digest, signature);
         return signer == SIGNER_ADDRESS;

--- a/packages/frontend/src/AppBootstrap.tsx
+++ b/packages/frontend/src/AppBootstrap.tsx
@@ -13,9 +13,7 @@ const shouldLoadRuntimeImmediately = () => {
   const searchParams = new URLSearchParams(window.location.search);
 
   return (
-    searchParams.has('code') ||
-    getLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN) !== null ||
-    getLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED) === 'true'
+    searchParams.has('code') || getLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED) === 'true'
   );
 };
 

--- a/packages/frontend/src/components/MainContent.test.tsx
+++ b/packages/frontend/src/components/MainContent.test.tsx
@@ -8,11 +8,13 @@ const guilds: SignedGuild[] = [
     id: '101',
     name: 'Linea Builders',
     signature: '0xsignature',
+    expirationDate: 1_769_459_200,
   },
   {
     id: '202',
     name: 'Verax Members',
     signature: '0xsignature',
+    expirationDate: 1_769_459_200,
     attestationId: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
   },
 ];

--- a/packages/frontend/src/hooks/useAttestationManager.test.tsx
+++ b/packages/frontend/src/hooks/useAttestationManager.test.tsx
@@ -38,6 +38,7 @@ const guild: SignedGuild = {
   id: '101',
   name: 'Linea Builders',
   signature: '0xsignature',
+  expirationDate: 1_769_459_200,
 };
 
 describe('useAttestationManager', () => {
@@ -73,6 +74,7 @@ describe('useAttestationManager', () => {
       expect.any(String),
       expect.objectContaining({
         schemaId: expect.any(String),
+        expirationDate: guild.expirationDate,
         subject: mocks.account.address,
         attestationData: [{ guildId: guild.id, guildName: guild.name }],
       }),

--- a/packages/frontend/src/hooks/useAttestationManager.ts
+++ b/packages/frontend/src/hooks/useAttestationManager.ts
@@ -1,7 +1,6 @@
 import type { Hex } from 'viem';
 import { useAccount } from 'wagmi';
 import { waitForTransactionReceipt } from 'viem/actions';
-import { addMonths } from 'date-fns/addMonths';
 import { useCallback, useState } from 'react';
 import type { VeraxSdk } from '@verax-attestation-registry/verax-sdk';
 import type { SignedGuild } from '../types';
@@ -50,7 +49,7 @@ export const useAttestationManager = (
           chainId === linea.id ? PORTAL_ID : PORTAL_ID_TESTNET,
           {
             schemaId: SCHEMA_ID,
-            expirationDate: Math.floor(addMonths(new Date(), 1).getTime() / 1000),
+            expirationDate: signedGuild.expirationDate,
             subject: address,
             attestationData: [{ guildId: signedGuild.id, guildName: signedGuild.name }],
           },

--- a/packages/frontend/src/hooks/useFetchGuilds.test.tsx
+++ b/packages/frontend/src/hooks/useFetchGuilds.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Address, Hex } from 'viem';
 import { useFetchGuilds } from './useFetchGuilds';
-import { setLocalStorageValue, STORAGE_KEYS } from '../utils/storage';
+import { removeLocalStorageValue, setLocalStorageValue, STORAGE_KEYS } from '../utils/storage';
 
 vi.mock('@verax-attestation-registry/verax-sdk', () => ({
   VeraxSdk: class VeraxSdk {},
@@ -37,16 +37,47 @@ describe('useFetchGuilds', () => {
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal('fetch', fetchMock);
+    window.history.pushState({}, '', '/');
+    window.localStorage.clear();
+    removeLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN);
+    removeLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED);
+    removeLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STATE);
   });
 
-  it('restores a legacy Discord session and enriches guilds with existing attestations', async () => {
-    const { sdk, findBy } = createSdk();
+  it('clears stored Discord tokens without restoring a session', async () => {
+    const { sdk } = createSdk();
     window.localStorage.setItem('discord_access_token', 'legacy-token');
-    mockApiResponse({
-      signedGuilds: [{ id: '101', name: 'Linea Builders', signature: '0xsignature' }],
-    });
+    setLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN, 'stored-token');
 
     const { result } = renderHook(() => useFetchGuilds(sdk, address, null, 59144));
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_ACCESS_TOKEN)).toBeNull(),
+    );
+
+    expect(result.current.isLoggedIn).toBe(false);
+    expect(result.current.guilds).toEqual([]);
+    expect(window.localStorage.getItem('discord_access_token')).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('exchanges an OAuth code, enriches guilds, and clears OAuth state without storing a token', async () => {
+    const { sdk, findBy } = createSdk();
+    setLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED, 'true');
+    setLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STATE, 'oauth-state');
+    window.history.pushState({}, '', '/?code=oauth-code&state=oauth-state');
+    mockApiResponse({
+      signedGuilds: [
+        {
+          id: '101',
+          name: 'Linea Builders',
+          signature: '0xsignature',
+          expirationDate: 1_769_459_200,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useFetchGuilds(sdk, address, 'oauth-code', 59141));
 
     await waitFor(() => expect(result.current.isLoggedIn).toBe(true));
 
@@ -55,6 +86,7 @@ describe('useFetchGuilds', () => {
         id: '101',
         name: 'Linea Builders',
         signature: '0xsignature',
+        expirationDate: 1_769_459_200,
         attestationId: '0xattestation',
       },
     ]);
@@ -63,48 +95,6 @@ describe('useFetchGuilds', () => {
       portal: expect.any(String),
       subject: address,
     });
-    expect(window.localStorage.getItem('discord_access_token')).toBeNull();
-
-    expect(fetchMock).toHaveBeenCalledWith('/.netlify/functions/api', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        isDev: 'false',
-        subject: address,
-        chainId: '59144',
-        accessToken: 'legacy-token',
-      }),
-    });
-  });
-
-  it('clears expired Discord tokens without logging the user in', async () => {
-    const { sdk } = createSdk();
-    window.localStorage.setItem(STORAGE_KEYS.DISCORD_ACCESS_TOKEN, 'expired-token');
-    mockApiResponse({ tokenExpired: true });
-
-    const { result } = renderHook(() => useFetchGuilds(sdk, address, null, 59144));
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-
-    expect(result.current.isLoggedIn).toBe(false);
-    expect(result.current.guilds).toEqual([]);
-    expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_ACCESS_TOKEN)).toBeNull();
-  });
-
-  it('exchanges an OAuth code, stores the returned token, and clears the OAuth marker', async () => {
-    const { sdk } = createSdk();
-    setLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED, 'true');
-    setLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STATE, 'oauth-state');
-    window.history.pushState({}, '', '/?code=oauth-code&state=oauth-state');
-    mockApiResponse({
-      accessToken: 'fresh-token',
-      signedGuilds: [{ id: '101', name: 'Linea Builders', signature: '0xsignature' }],
-    });
-
-    const { result } = renderHook(() => useFetchGuilds(sdk, address, 'oauth-code', 59141));
-
-    await waitFor(() => expect(result.current.isLoggedIn).toBe(true));
-
     expect(fetchMock).toHaveBeenCalledWith('/.netlify/functions/api', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -115,9 +105,26 @@ describe('useFetchGuilds', () => {
         code: 'oauth-code',
       }),
     });
-    expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_ACCESS_TOKEN)).toBe('fresh-token');
+    expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_ACCESS_TOKEN)).toBeNull();
     expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_OAUTH_STARTED)).toBeNull();
     expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_OAUTH_STATE)).toBeNull();
     expect(window.location.search).toBe('');
+  });
+
+  it('does not exchange an OAuth code when state does not match', async () => {
+    const { sdk } = createSdk();
+    setLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED, 'true');
+    setLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STATE, 'expected-state');
+    window.history.pushState({}, '', '/?code=oauth-code&state=attacker-state');
+
+    const { result } = renderHook(() => useFetchGuilds(sdk, address, 'oauth-code', 59141));
+
+    await waitFor(() => expect(window.location.search).toBe(''));
+
+    expect(result.current.isLoggedIn).toBe(false);
+    expect(result.current.guilds).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_OAUTH_STARTED)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.DISCORD_OAUTH_STATE)).toBeNull();
   });
 });

--- a/packages/frontend/src/hooks/useFetchGuilds.ts
+++ b/packages/frontend/src/hooks/useFetchGuilds.ts
@@ -1,19 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { DecodedPayload, SignedGuild } from '../types';
 import type { Address, Hex } from 'viem';
 import type { VeraxSdk } from '@verax-attestation-registry/verax-sdk';
 import { PORTAL_ID, PORTAL_ID_TESTNET, SCHEMA_ID } from '../utils/constants';
 import { linea } from 'wagmi/chains';
-import {
-  getLocalStorageValue,
-  migrateLocalStorageValue,
-  removeLocalStorageValue,
-  setLocalStorageValue,
-  STORAGE_KEYS,
-} from '../utils/storage';
+import { getLocalStorageValue, removeLocalStorageValue, STORAGE_KEYS } from '../utils/storage';
 
 const LEGACY_DISCORD_TOKEN_KEY = 'discord_access_token';
-const LEGACY_DISCORD_OAUTH_STARTED_KEY = 'discord_oauth_started';
 
 const getApiBaseUrl = () => {
   const isLocalViteDevServer = import.meta.env.DEV && window.location.port === '5173';
@@ -44,12 +37,17 @@ const getInitialOAuthLoadingState = (code?: string | null) => {
     return false;
   }
 
-  return (
-    migrateLocalStorageValue(
-      LEGACY_DISCORD_OAUTH_STARTED_KEY,
-      STORAGE_KEYS.DISCORD_OAUTH_STARTED,
-    ) === 'true' && isValidOAuthState()
-  );
+  return getLocalStorageValue(STORAGE_KEYS.DISCORD_OAUTH_STARTED) === 'true' && isValidOAuthState();
+};
+
+const clearStoredDiscordTokens = () => {
+  removeLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN);
+
+  try {
+    window.localStorage.removeItem(LEGACY_DISCORD_TOKEN_KEY);
+  } catch {
+    // Ignore unavailable storage.
+  }
 };
 
 export const useFetchGuilds = (
@@ -61,7 +59,6 @@ export const useFetchGuilds = (
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(() => getInitialOAuthLoadingState(code));
   const [guilds, setGuilds] = useState<SignedGuild[]>([]);
-  const hasRestoredSession = useRef(false);
 
   const enrichGuildsWithAttestations = useCallback(
     async (signedGuilds: SignedGuild[], sdk: VeraxSdk): Promise<SignedGuild[]> => {
@@ -88,7 +85,7 @@ export const useFetchGuilds = (
   );
 
   const fetchGuildsFromApi = useCallback(
-    async (params: { code?: string; accessToken?: string }) => {
+    async (params: { code: string }) => {
       const baseUrl = getApiBaseUrl();
       const isDev = baseUrl !== '';
 
@@ -96,8 +93,7 @@ export const useFetchGuilds = (
         isDev: String(isDev),
         subject: address as string,
         chainId: String(chainId),
-        ...(params.code ? { code: params.code } : {}),
-        ...(params.accessToken ? { accessToken: params.accessToken } : {}),
+        code: params.code,
       };
 
       try {
@@ -108,27 +104,12 @@ export const useFetchGuilds = (
         });
         const data = await res.json();
 
-        if (data.tokenExpired) {
-          removeLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN);
-          return null;
-        }
-
         if (data.error || data.message) {
-          if (params.accessToken) {
-            removeLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN);
-          }
           return null;
-        }
-
-        if (data.accessToken) {
-          setLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN, data.accessToken);
         }
 
         return data.signedGuilds as SignedGuild[];
       } catch {
-        if (params.accessToken) {
-          removeLocalStorageValue(STORAGE_KEYS.DISCORD_ACCESS_TOKEN);
-        }
         return null;
       }
     },
@@ -136,43 +117,8 @@ export const useFetchGuilds = (
   );
 
   useEffect(() => {
-    if (hasRestoredSession.current || !veraxSdk || !address || !chainId || isLoggedIn) {
-      return;
-    }
-
-    const storedToken = migrateLocalStorageValue(
-      LEGACY_DISCORD_TOKEN_KEY,
-      STORAGE_KEYS.DISCORD_ACCESS_TOKEN,
-    );
-    if (!storedToken) {
-      return;
-    }
-
-    hasRestoredSession.current = true;
-    let isCurrent = true;
-
-    const restoreSession = async () => {
-      setIsLoading(true);
-      try {
-        const signedGuilds = await fetchGuildsFromApi({ accessToken: storedToken });
-        if (signedGuilds && isCurrent) {
-          const enrichedGuilds = await enrichGuildsWithAttestations(signedGuilds, veraxSdk);
-          setGuilds(enrichedGuilds);
-          setIsLoggedIn(true);
-        }
-      } finally {
-        if (isCurrent) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void restoreSession();
-
-    return () => {
-      isCurrent = false;
-    };
-  }, [veraxSdk, address, chainId, isLoggedIn, fetchGuildsFromApi, enrichGuildsWithAttestations]);
+    clearStoredDiscordTokens();
+  }, []);
 
   useEffect(() => {
     if (!isLoading || !code || !veraxSdk) {

--- a/packages/frontend/src/types/index.d.ts
+++ b/packages/frontend/src/types/index.d.ts
@@ -7,6 +7,7 @@ export interface Guild {
 
 export interface SignedGuild extends Guild {
   signature: string;
+  expirationDate: number;
   attestationId?: Hex;
 }
 

--- a/packages/functions/api.ts
+++ b/packages/functions/api.ts
@@ -1,29 +1,40 @@
 import axios from 'axios';
 import type { Guild } from './lib/types';
-import { createWalletClient, http } from 'viem';
-import type { Hex, WalletClient } from 'viem';
+import { createWalletClient, getAddress, http, isAddress } from 'viem';
+import type { Address, Hex, WalletClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { linea } from 'viem/chains';
+import { linea, lineaSepolia } from 'viem/chains';
 import { PORTAL_ID, PORTAL_ID_TESTNET } from './lib/constants';
-import type { Context } from '@netlify/functions';
 
 const { VITE_DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, VITE_REDIRECT_URL, SIGNER_PRIVATE_KEY } =
   process.env;
 const DEV_REDIRECT_URL = 'http://localhost:5173';
+const ATTESTATION_VALIDITY_SECONDS = 30 * 24 * 60 * 60;
+const SUPPORTED_CHAIN_IDS: ReadonlySet<number> = new Set([linea.id, lineaSepolia.id]);
 
-const headers = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-  'Content-Type': 'application/json',
+const getHeaders = (req: Request) => {
+  const origin = req.headers.get('origin');
+  const allowedOrigins = new Set(
+    [VITE_REDIRECT_URL, DEV_REDIRECT_URL, 'http://127.0.0.1:5173'].filter(Boolean),
+  );
+  const allowedOrigin =
+    origin && allowedOrigins.has(origin) ? origin : (VITE_REDIRECT_URL ?? DEV_REDIRECT_URL);
+
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Cache-Control': 'no-store',
+    'Content-Type': 'application/json',
+    Vary: 'Origin',
+  };
 };
 
 interface ApiPayload {
-  code?: string;
-  accessToken?: string;
-  isDev?: boolean | string;
-  subject?: string;
-  chainId?: number | string;
+  code?: unknown;
+  isDev?: unknown;
+  subject?: unknown;
+  chainId?: unknown;
 }
 
 const checkConfig = () => {
@@ -57,41 +68,62 @@ const getGuilds = async (accessToken: string) => {
   return response.data as Guild[];
 };
 
-const getRequestPayload = async (req: Request, context: Context): Promise<ApiPayload> => {
-  if (req.method === 'POST') {
-    return (await req.json()) as ApiPayload;
+const getRequestPayload = async (req: Request): Promise<ApiPayload | null> => {
+  try {
+    const payload = (await req.json()) as unknown;
+    return payload && typeof payload === 'object' ? (payload as ApiPayload) : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseCode = (value: unknown) =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
+const parseSubject = (value: unknown): Address | null => {
+  if (typeof value !== 'string' || !isAddress(value)) {
+    return null;
   }
 
-  const { searchParams } = context.url;
+  return getAddress(value);
+};
 
-  return {
-    code: searchParams.get('code') ?? undefined,
-    accessToken: searchParams.get('accessToken') ?? undefined,
-    isDev: searchParams.get('isDev') ?? undefined,
-    subject: searchParams.get('subject') ?? undefined,
-    chainId: searchParams.get('chainId') ?? undefined,
-  };
+const parseSupportedChainId = (value: unknown) => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const chainIdValue = String(value);
+  if (!/^\d+$/.test(chainIdValue)) {
+    return null;
+  }
+
+  const chainId = Number(chainIdValue);
+  return SUPPORTED_CHAIN_IDS.has(chainId) ? chainId : null;
 };
 
 const signGuilds = async (
   walletClient: WalletClient,
   guilds: Guild[],
-  subject: string,
+  subject: Address,
   chainId: number,
+  expirationDate: bigint,
 ) => {
   const domain = {
     name: 'VerifyDiscord',
     version: '1',
-    chainId: chainId,
+    chainId,
     verifyingContract: chainId === linea.id ? PORTAL_ID : PORTAL_ID_TESTNET,
   } as const;
 
   const types = {
     Discord: [
       { name: 'id', type: 'uint256' },
+      { name: 'name', type: 'string' },
       { name: 'subject', type: 'address' },
+      { name: 'expirationDate', type: 'uint64' },
     ],
-  };
+  } as const;
 
   const account = walletClient.account;
 
@@ -103,7 +135,9 @@ const signGuilds = async (
     guilds.map(async (guild) => {
       const message = {
         id: BigInt(guild.id),
+        name: guild.name,
         subject,
+        expirationDate,
       };
 
       const signature = await walletClient.signTypedData({
@@ -114,17 +148,24 @@ const signGuilds = async (
         message,
       });
 
-      return { id: guild.id, name: guild.name, signature };
+      return {
+        id: guild.id,
+        name: guild.name,
+        signature,
+        expirationDate: Number(expirationDate),
+      };
     }),
   );
 };
 
-export default async (req: Request, context: Context) => {
+export default async (req: Request) => {
+  const headers = getHeaders(req);
+
   if (req.method === 'OPTIONS') {
     return new Response('', { status: 204, headers });
   }
 
-  if (req.method !== 'GET' && req.method !== 'POST') {
+  if (req.method !== 'POST') {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), {
       status: 405,
       headers,
@@ -134,24 +175,27 @@ export default async (req: Request, context: Context) => {
   try {
     checkConfig();
 
-    const payload = await getRequestPayload(req, context);
-    const code = payload.code;
-    const existingToken = payload.accessToken;
-    const isDev = payload.isDev === true || payload.isDev === 'true';
-    const subject = payload.subject;
-    const rawChainId = payload.chainId;
+    const payload = await getRequestPayload(req);
+    if (!payload) {
+      return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+        status: 400,
+        headers,
+      });
+    }
 
-    if ((!code && !existingToken) || !subject || !rawChainId) {
+    const code = parseCode(payload.code);
+    const isDev = payload.isDev === true || payload.isDev === 'true';
+    const subject = parseSubject(payload.subject);
+    const chainId = parseSupportedChainId(payload.chainId);
+
+    if (!code || !subject || !chainId) {
       return new Response(JSON.stringify({ error: 'Missing parameters' }), {
         status: 400,
         headers,
       });
     }
 
-    const chainId = parseInt(String(rawChainId), 10);
-
-    // Use existing token or exchange OAuth code for a new one
-    const accessToken = existingToken ?? (await getToken(code as string, isDev));
+    const accessToken = await getToken(code, isDev);
 
     let guilds: Guild[];
     try {
@@ -167,14 +211,16 @@ export default async (req: Request, context: Context) => {
       throw error;
     }
 
+    const expirationDate = BigInt(Math.floor(Date.now() / 1000) + ATTESTATION_VALIDITY_SECONDS);
+
     const walletClient = createWalletClient({
       account: privateKeyToAccount(SIGNER_PRIVATE_KEY as Hex),
       transport: http('https://rpc.linea.build'),
     });
 
-    const signedGuilds = await signGuilds(walletClient, guilds, subject, chainId);
+    const signedGuilds = await signGuilds(walletClient, guilds, subject, chainId, expirationDate);
 
-    return new Response(JSON.stringify({ signedGuilds, accessToken }), {
+    return new Response(JSON.stringify({ signedGuilds }), {
       status: 200,
       headers,
     });


### PR DESCRIPTION
## Summary
- bind on-chain Discord attestations to the submitting wallet subject
- include guild name and expiration date in the signed EIP-712 payload
- remove Discord token persistence/query-string transport and harden API request validation/CORS
- update audit reports with remediation status and deployment blocker details

## Validation
- pnpm --filter @discord-attestation/contracts exec hardhat compile --force
- pnpm --filter @discord-attestation/contracts test
- pnpm --filter @discord-attestation/frontend typecheck
- pnpm --filter @discord-attestation/functions typecheck
- pnpm --filter @discord-attestation/frontend test
- pnpm --filter @discord-attestation/frontend build
- pnpm --filter @discord-attestation/frontend test:e2e
- pnpm lint