### PR TITLE
fix: update hardened portal addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ pnpm --filter @discord-attestation/functions dev
 ### Linea Sepolia (Testnet)
 
 [
-`0xd0fb47ea3960d15425137b2ff83955c3beb6a85c`](https://explorer.ver.ax/linea-sepolia/portals/0xd0fb47ea3960d15425137b2ff83955c3beb6a85c)
+`0xf22f348c9257f418509ec03d6bc0c31a20bd9e46`](https://explorer.ver.ax/linea-sepolia/portals/0xf22f348c9257f418509ec03d6bc0c31a20bd9e46)
 
 ### Linea Mainnet
 
 [
-`0x407e280281b812adef69a91230659c9d738d82cb`](https://explorer.ver.ax/linea/portals/0x407e280281b812adef69a91230659c9d738d82cb)
+`0x6c3ba43a3c4ac6579d44baeb84e9cfc23654964f`](https://explorer.ver.ax/linea/portals/0x6c3ba43a3c4ac6579d44baeb84e9cfc23654964f)
 
 ### Schema
 

--- a/packages/frontend/src/utils/constants.ts
+++ b/packages/frontend/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import type { Address, Hex } from 'viem';
 
-export const PORTAL_ID_TESTNET: Address = '0xd0Fb47EA3960d15425137B2fF83955c3beb6a85c';
-export const PORTAL_ID: Address = '0x407e280281B812Adef69A91230659C9D738D82Cb';
+export const PORTAL_ID_TESTNET: Address = '0xf22f348C9257F418509eC03d6BC0C31A20Bd9E46';
+export const PORTAL_ID: Address = '0x6C3Ba43a3c4aC6579D44Baeb84e9CFC23654964f';
 export const SCHEMA_ID: Hex = '0xefa96ce61912c5bb59cb4c26645ea193fc03a234fe09a6b2c8b85aaa51a382d6';

--- a/packages/functions/lib/constants.ts
+++ b/packages/functions/lib/constants.ts
@@ -1,5 +1,4 @@
 import type { Address } from 'viem';
 
-export const PORTAL_ID_TESTNET: Address = '0xd0Fb47EA3960d15425137B2fF83955c3beb6a85c';
-export const PORTAL_ID: Address = '0x407e280281B812Adef69A91230659C9D738D82Cb';
-
+export const PORTAL_ID_TESTNET: Address = '0xf22f348C9257F418509eC03d6BC0C31A20Bd9E46';
+export const PORTAL_ID: Address = '0x6C3Ba43a3c4aC6579D44Baeb84e9CFC23654964f';


### PR DESCRIPTION
## Summary
- update frontend and function portal constants to the redeployed hardened Discord portals
- refresh README portal links from the updated constants

## Validation
- verified bytecode exists at both new portal addresses via Linea and Linea Sepolia RPC
- pnpm --filter @discord-attestation/frontend typecheck
- pnpm --filter @discord-attestation/functions typecheck
- pnpm --filter @discord-attestation/frontend build
- pre-commit lint/typecheck/update-readme hooks