### PR TITLE
fix: return successful CORS preflight

### DIFF
--- a/packages/functions/api.ts
+++ b/packages/functions/api.ts
@@ -162,7 +162,7 @@ export default async (req: Request) => {
   const headers = getHeaders(req);
 
   if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers });
+    return new Response(null, { status: 200, headers });
   }
 
   if (req.method !== 'POST') {


### PR DESCRIPTION
## Summary
- return a 200 CORS preflight response for the Netlify function because the deployed runtime rejects 204 responses in this handler path

## Validation
- pnpm --filter @discord-attestation/functions typecheck
- pre-commit lint/typecheck/update-readme hooks
- verified the previous production OPTIONS request was returning 502 with the 204 response path